### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/WizFi210/keywords.txt
+++ b/WizFi210/keywords.txt
@@ -6,37 +6,37 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SPIChar                       	KEYWORD1
-WizFi2x0Class			KEYWORD1
-TimeoutClass			KEYWORD1
+SPIChar	KEYWORD1
+WizFi2x0Class	KEYWORD1
+TimeoutClass	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init	        		KEYWORD2
-Setup                          	KEYWORD2
-write                           KEYWORD2
-read                           	KEYWORD2
-ByteStuff                 	KEYWORD2
-CheckReply			KEYWORD2
-CheckSync			KEYWORD2
-ParseReply			KEYWORD2
-SendSync			KEYWORD2
-TimerStart			KEYWORD2
-TimerStop			KEYWORD2
-GetIsTimeout			KEYWORD2
-CheckIsTimeout			KEYWORD2
-SendCommand			KEYWORD2
+init	KEYWORD2
+Setup	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+ByteStuff	KEYWORD2
+CheckReply	KEYWORD2
+CheckSync	KEYWORD2
+ParseReply	KEYWORD2
+SendSync	KEYWORD2
+TimerStart	KEYWORD2
+TimerStop	KEYWORD2
+GetIsTimeout	KEYWORD2
+CheckIsTimeout	KEYWORD2
+SendCommand	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-WizFi2x0_RST			LITERAL1
-WizFi2x0_DataReady		LITERAL1
-WizFi2x0_CS			LITERAL1
-WizFi2x0_CmdState_IDLE		LITERAL1
-WizFi2x0_CmdState_Sent		LITERAL1
-WizFi2x0_CmdState_Rcvd		LITERAL1
+WizFi2x0_RST	LITERAL1
+WizFi2x0_DataReady	LITERAL1
+WizFi2x0_CS	LITERAL1
+WizFi2x0_CmdState_IDLE	LITERAL1
+WizFi2x0_CmdState_Sent	LITERAL1
+WizFi2x0_CmdState_Rcvd	LITERAL1
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords